### PR TITLE
Update `JoinRaw` bindings type to accept arrays

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1259,7 +1259,7 @@ export declare namespace Knex {
   }
 
   interface JoinRaw<TRecord = any, TResult = unknown[]> {
-    (tableName: string, binding?: Value | ValueDict): QueryBuilder<
+    (tableName: string, binding?: Value | Value[] | ValueDict): QueryBuilder<
       TRecord,
       TResult
     >;


### PR DESCRIPTION
This extends the bindings in the `JoinRaw` type to accept arrays. 

Example use case in postgres:
```js
knex('table').joinRaw(
  `join (
    SELECT id
    FROM joined_table jt
    WHERE jt.id = ?
    AND jt.value = ANY(?)
  ) AS j ON j.id = t.id`,
  [123, ['value one', 'value two']],
);
```

